### PR TITLE
Adapter: fix README.md and parsers.js

### DIFF
--- a/content/adapter/javascript/functions/README.md
+++ b/content/adapter/javascript/functions/README.md
@@ -162,12 +162,12 @@ const parsers = {
   },
 };
 
-export default format => (data) => {
-  const parse = parsers[format];
-  if (!parse) {
+export default format => {
+  const parser = parsers[format];
+  if (!parser) {
     throw new Error(`unkown format: ${format}`);
   }
-  return parse(data);
+  return parser;
 };
 ```
 

--- a/content/adapter/javascript/functions/parsers.js
+++ b/content/adapter/javascript/functions/parsers.js
@@ -18,10 +18,10 @@ const parsers = {
   },
 };
 
-export default format => (data) => {
-  const parse = parsers[format];
-  if (!parse) {
+export default format => {
+  const parser = parsers[format];
+  if (!parser) {
     throw new Error(`unkown format: ${format}`);
   }
-  return parse(data);
+  return parser;
 };


### PR DESCRIPTION
В последнем примере мы должны возвращать "объект с нужным набором функций".